### PR TITLE
Re-work Server constructor

### DIFF
--- a/oidcserver/oauth2_test.go
+++ b/oidcserver/oauth2_test.go
@@ -148,8 +148,12 @@ func TestParseAuthorizationRequest(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			httpServer, server := newTestServer(ctx, t, func(c *Config) {
-				c.SupportedResponseTypes = tc.supportedResponseTypes
+			httpServer, server := newTestServer(ctx, t, func(s *Server) {
+				srt := map[string]bool{}
+				for _, rt := range tc.supportedResponseTypes {
+					srt[rt] = true
+				}
+				s.supportedResponseTypes = srt
 			})
 			defer httpServer.Close()
 


### PR DESCRIPTION
This makes setting up a server more consumer friendly. Move to a New method
that has required args for things we need, and functional args for the things
we optionally accept.