### PR TITLE
Promote ID generation to storage package

### DIFF
--- a/oidcserver/handlers.go
+++ b/oidcserver/handlers.go
@@ -294,7 +294,7 @@ func (s *Server) sendCodeResponse(w http.ResponseWriter, r *http.Request, authRe
 				return
 			}
 			code = &storagepb.AuthCode{
-				Id:            NewID(),
+				Id:            storage.NewID(),
 				ClientId:      authReq.ClientId,
 				ConnectorId:   authReq.ConnectorId,
 				Nonce:         authReq.Nonce,
@@ -509,8 +509,8 @@ func (s *Server) handleAuthCode(w http.ResponseWriter, r *http.Request, client *
 			return
 		}
 		refresh := &storagepb.RefreshToken{
-			Id:            NewID(),
-			Token:         NewID(),
+			Id:            storage.NewID(),
+			Token:         storage.NewID(),
 			ClientId:      authCode.ClientId,
 			ConnectorId:   authCode.ConnectorId,
 			Scopes:        authCode.Scopes,
@@ -734,7 +734,7 @@ func (s *Server) handleRefreshToken(w http.ResponseWriter, r *http.Request, clie
 
 	newToken := &internal.RefreshToken{
 		RefreshId: refresh.Id,
-		Token:     NewID(),
+		Token:     storage.NewID(),
 	}
 	rawNewToken, err := internal.Marshal(newToken)
 	if err != nil {

--- a/oidcserver/oauth2.go
+++ b/oidcserver/oauth2.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/heroku/deci/oidcserver/internal"
 	storagepb "github.com/heroku/deci/proto/deci/storage/v1beta1"
+	"github.com/heroku/deci/storage"
 	jose "gopkg.in/square/go-jose.v2"
 )
 
@@ -215,7 +216,7 @@ type federatedIDClaims struct {
 }
 
 func (s *Server) newAccessToken(clientID string, claims *storagepb.Claims, scopes []string, nonce, connID string) (accessToken string, err error) {
-	idToken, _, err := s.newIDToken(clientID, claims, scopes, nonce, NewID(), connID)
+	idToken, _, err := s.newIDToken(clientID, claims, scopes, nonce, storage.NewID(), connID)
 	return idToken, err
 }
 
@@ -440,7 +441,7 @@ func (s *Server) parseAuthorizationRequest(r *http.Request) (req *storagepb.Auth
 	}
 
 	return &storagepb.AuthRequest{
-		Id:                  NewID(),
+		Id:                  storage.NewID(),
 		ClientId:            client.ID,
 		State:               state,
 		Nonce:               nonce,

--- a/oidcserver/storage.go
+++ b/oidcserver/storage.go
@@ -1,30 +1,8 @@
 package oidcserver
 
-import (
-	"crypto/rand"
-	"encoding/base32"
-	"io"
-	"strings"
-)
-
 const (
 	authReqKeyspace         = "auth-request"
 	authCodeKeyspace        = "auth-code"
 	refreshTokenKeyspace    = "refresh-token"
 	offlineSessionsKeyspace = "offline-session"
 )
-
-// Kubernetes only allows lower case letters for names.
-//
-// TODO(ericchiang): refactor ID creation onto the storage.
-var encoding = base32.NewEncoding("abcdefghijklmnopqrstuvwxyz234567")
-
-// NewID returns a random string which can be used as an ID for objects.
-func NewID() string {
-	buff := make([]byte, 16) // 128 bit random ID.
-	if _, err := io.ReadFull(rand.Reader, buff); err != nil {
-		panic(err)
-	}
-	// Avoid the identifier to begin with number and trim padding
-	return string(buff[0]%26+'a') + strings.TrimRight(encoding.EncodeToString(buff[1:]), "=")
-}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2,6 +2,10 @@ package storage
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base32"
+	"io"
+	"strings"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -51,4 +55,19 @@ type errConflict interface {
 func IsConflictErr(err error) bool {
 	_, ok := err.(errConflict)
 	return ok
+}
+
+// Kubernetes only allows lower case letters for names.
+//
+// TODO(ericchiang): refactor ID creation onto the storage.
+var encoding = base32.NewEncoding("abcdefghijklmnopqrstuvwxyz234567")
+
+// NewID returns a random string which can be used as an ID for objects.
+func NewID() string {
+	buff := make([]byte, 16) // 128 bit random ID.
+	if _, err := io.ReadFull(rand.Reader, buff); err != nil {
+		panic(err)
+	}
+	// Avoid the identifier to begin with number and trim padding
+	return string(buff[0]%26+'a') + strings.TrimRight(encoding.EncodeToString(buff[1:]), "=")
 }


### PR DESCRIPTION
If we share `storage.Storage` with other packages, it would be nice to
have a standard ID generation method in the same package.