### PR TITLE
Ensure signed JWT's have KeyID Header

### DIFF
--- a/signer/rotation.go
+++ b/signer/rotation.go
@@ -274,7 +274,7 @@ func (r *RotatingSigner) Sign(ctx context.Context, data []byte) ([]byte, error) 
 	}
 	sk := jose.SigningKey{
 		Algorithm: jose.SignatureAlgorithm(swk.Algorithm),
-		Key:       swk.Key,
+		Key:       swk,
 	}
 	return sign(ctx, sk, data)
 }


### PR DESCRIPTION
We were seeing issues where the signed JWT's did not have a KeyID header set to
the right value, which cause issues locating the corresponding public key to
verify the signature against.

Turns out this is because we weren't passing the correct value to the
SigningKey - it takes an `interface{}`, which worked for both the raw RSA key
which has no concept of a JWK KeyID, as well as a `jose.JSONWebKey` which does.
Fix by passing the JWK to the SigningKey, and update the test to ensure all
signed tokens contain a KeyID.