### PR TITLE
Setup for certification testing

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: deci-simple

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: deci-simple
+web: deci-simple --issuer=$ISSUER --listen=0.0.0.0:$PORT

--- a/cmd/deci-simple/main.go
+++ b/cmd/deci-simple/main.go
@@ -65,6 +65,14 @@ func main() {
 			Secret:       "ZXhhbXBsZS1hcHAtc2VjcmV0",
 			RedirectURIs: []string{"http://127.0.0.1:5555/callback"},
 		},
+		{
+			ID:     "openid-certification",
+			Secret: "openid-certification",
+			RedirectURIs: []string{
+				"https://op.certification.openid.net:61944/authz_cb",
+				"https://op.certification.openid.net:61944/authz_post",
+			},
+		},
 	})
 
 	server, err := oidcserver.New((*issuer).String(), stor, signer, clients, oidcserver.WithLogger(l), oidcserver.WithSkipApprovalScreen(*skipConsent))

--- a/cmd/deci-simple/main.go
+++ b/cmd/deci-simple/main.go
@@ -11,10 +11,12 @@ import (
 	"net/http"
 
 	oidc "github.com/coreos/go-oidc"
+	_ "github.com/lib/pq"
 	"github.com/pardot/deci/oidcserver"
 	"github.com/pardot/deci/signer"
+	"github.com/pardot/deci/storage"
+	"github.com/pardot/deci/storage/memory"
 	sqlstor "github.com/pardot/deci/storage/sql"
-	_ "github.com/lib/pq"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -26,9 +28,10 @@ func main() {
 	l := logrus.New()
 
 	var (
-		issuer = kingpin.Flag("issuer", "Issuer URL to serve as").Default("http://localhost:5556/dex").URL()
-		dbURL  = kingpin.Flag("db", "URL to Postgres database").Default("postgres://localhost/deci_dev?sslmode=disable").String()
-		listen = kingpin.Flag("listen", "Addr to listen on").Default("127.0.0.1:5556").String()
+		issuer      = kingpin.Flag("issuer", "Issuer URL to serve as").Default("http://localhost:5556").URL()
+		dbURL       = kingpin.Flag("db", "URL to Postgres database, e.g postgres://localhost/deci_dev?sslmode=disable. If empty, in-memory is used.").String()
+		listen      = kingpin.Flag("listen", "Addr to listen on").Default("127.0.0.1:5556").String()
+		skipConsent = kingpin.Flag("skip-consent", "Skip the default user consent screen").Default("true").Bool()
 
 		// OIDC connector options (optional)
 		oidcIssuer       = kingpin.Flag("oidc-issuer", "Upstream OIDC issuer URL").URL()
@@ -37,14 +40,19 @@ func main() {
 	)
 	kingpin.Parse()
 
-	db, err := sql.Open("postgres", *dbURL)
-	if err != nil {
-		l.WithError(err).Fatal("Failed to open SQL connection")
-	}
+	var stor storage.Storage
+	if *dbURL != "" {
+		db, err := sql.Open("postgres", *dbURL)
+		if err != nil {
+			l.WithError(err).Fatal("Failed to open SQL connection")
+		}
 
-	stor, err := sqlstor.New(ctx, db)
-	if err != nil {
-		l.WithError(err).Fatal("Failed to initialize storage")
+		stor, err = sqlstor.New(ctx, db)
+		if err != nil {
+			l.WithError(err).Fatal("Failed to initialize storage")
+		}
+	} else {
+		stor = memory.New()
 	}
 
 	privs, pubs := mustGenKeyset(2)
@@ -59,7 +67,7 @@ func main() {
 		},
 	})
 
-	server, err := oidcserver.New((*issuer).String(), stor, signer, clients, oidcserver.WithLogger(l))
+	server, err := oidcserver.New((*issuer).String(), stor, signer, clients, oidcserver.WithLogger(l), oidcserver.WithSkipApprovalScreen(*skipConsent))
 	if err != nil {
 		l.WithError(err).Fatal("Failed to construct server")
 	}

--- a/docs/certification.md
+++ b/docs/certification.md
@@ -1,0 +1,7 @@
+# Certfication
+
+The aim is to have a certified OIDC implementation. Currently this is not the case.
+
+An instance of `deci-simple` is deployed to https://deci-simple.herokuapp.com . This is currently targeted by the certification instance at https://op.certification.openid.net:61944
+
+More details on the certification process can be found at https://openid.net/certification/

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/pardot/deci
 
+// +heroku goVersion go1.13
+// +heroku install ./cmd/...
+
 go 1.13
 
 require (


### PR DESCRIPTION
We would like to have this be a conformant implementation.

This sets up deployment of `deci-simple` to Heroku, which can be targeted by the certification suite at https://op.certification.openid.net:60000

Current results at https://op.certification.openid.net:61944