### PR TITLE
Bring back connector.Initialize

### DIFF
--- a/oidcserver/authenticator.go
+++ b/oidcserver/authenticator.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes/wrappers"
 	storagepb "github.com/pardot/deci/proto/deci/storage/v1beta1"
+	"github.com/sirupsen/logrus"
 )
 
 // Authenticator is capable of associating the user's identity with a given
@@ -53,13 +54,17 @@ func (a *authenticator) Authenticate(ctx context.Context, authID string, ident I
 		return "", fmt.Errorf("failed to update auth request: %v", err)
 	}
 
-	email := claims.Email
-	if !claims.EmailVerified {
-		email = email + " (unverified)"
-	}
-
-	a.s.logger.Infof("login successful: connector %q, username=%q, email=%q, groups=%q",
-		authReq.ConnectorId, claims.Username, email, claims.Groups)
+	a.s.logger.WithFields(logrus.Fields{
+		"authid":    authID,
+		"connector": authReq.ConnectorId,
+		"userid":    claims.UserId,
+		"username":  claims.Username,
+		"email":     claims.Email,
+		"groups":    claims.Groups,
+		"acr":       claims.Acr,
+		"amr":       claims.Amr,
+		"at":        "login-successful",
+	}).Info()
 
 	return a.s.absURL("/approval") + "?req=" + authReq.Id, nil
 }

--- a/oidcserver/connector.go
+++ b/oidcserver/connector.go
@@ -54,6 +54,12 @@ type LoginRequest struct {
 
 // Connector is used to actually manage the end user authentication
 type Connector interface {
+	// Initialize is called by Server before the connectors first authentication
+	// flow. This passes an Authenticator which the connector can use to assign
+	// an identity to the authorization flow, and determine the final URL to
+	// send the user to
+	Initialize(auth Authenticator)
+
 	// LoginPage is called at the start of an authentication flow. This method
 	// can render/return whatever it wants and run the user through any
 	// arbitrary intermediate pages. The only requirement is that it threads the

--- a/oidcserver/connector_test.go
+++ b/oidcserver/connector_test.go
@@ -8,7 +8,7 @@ import (
 
 // newMockConnector returns a mock connector which requires no user interaction. It always returns
 // the same (fake) identity.
-func newMockConnector(authenticator Authenticator) *mockConnector {
+func newMockConnector() *mockConnector {
 	ident := Identity{
 		UserID:        "0-385-28089-0",
 		Username:      "Kilgore Trout",
@@ -25,7 +25,6 @@ func newMockConnector(authenticator Authenticator) *mockConnector {
 		refreshFunc: func(_ Identity) Identity {
 			return ident
 		},
-		authenticator: authenticator,
 	}
 }
 
@@ -43,6 +42,10 @@ type mockConnector struct {
 	refreshFunc func(Identity) Identity
 
 	authenticator Authenticator
+}
+
+func (m *mockConnector) Initialize(authenticator Authenticator) {
+	m.authenticator = authenticator
 }
 
 func (m *mockConnector) LoginPage(w http.ResponseWriter, r *http.Request, lr LoginRequest) {

--- a/oidcserver/handlers.go
+++ b/oidcserver/handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pardot/deci/oidcserver/internal"
 	storagepb "github.com/pardot/deci/proto/deci/storage/v1beta1"
 	"github.com/pardot/deci/storage"
+	"github.com/sirupsen/logrus"
 	jose "gopkg.in/square/go-jose.v2"
 )
 
@@ -791,6 +792,17 @@ func (s *Server) handleRefreshToken(w http.ResponseWriter, r *http.Request, clie
 		s.tokenErrHelper(w, errServerError, "", http.StatusInternalServerError)
 		return
 	}
+
+	s.logger.WithFields(logrus.Fields{
+		"connector": refresh.ConnectorId,
+		"userid":    refresh.Claims.UserId,
+		"username":  refresh.Claims.Username,
+		"email":     refresh.Claims.Email,
+		"groups":    refresh.Claims.Groups,
+		"acr":       refresh.Claims.Acr,
+		"amr":       refresh.Claims.Amr,
+		"at":        "refresh-successful",
+	}).Info()
 
 	s.writeAccessToken(w, idToken, accessToken, rawNewToken, expiry)
 }

--- a/oidcserver/server_test.go
+++ b/oidcserver/server_test.go
@@ -103,6 +103,7 @@ func newTestServer(_ context.Context, t *testing.T, updateServer func(s *Server)
 			Use:       "sig",
 		},
 	}
+	connectors := map[string]Connector{"mock": newMockConnector()}
 	signer := signer.NewStatic(signingKey, verificationKeys)
 
 	// make the updater into an option, so we can change the server a bit before
@@ -116,12 +117,8 @@ func newTestServer(_ context.Context, t *testing.T, updateServer func(s *Server)
 		return nil
 	}
 
-	server, err = New(s.URL, stor, signer, nil, WithLogger(logger), WithSkipApprovalScreen(true), usOpt)
+	server, err = New(s.URL, stor, signer, connectors, nil, WithLogger(logger), WithSkipApprovalScreen(true), usOpt)
 	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := server.AddConnector("mock", newMockConnector(server.Authenticator())); err != nil {
 		t.Fatal(err)
 	}
 

--- a/storage/sql/sql_test.go
+++ b/storage/sql/sql_test.go
@@ -3,34 +3,27 @@ package sql
 import (
 	"context"
 	"database/sql"
-	"flag"
+	"os"
 	"testing"
 
-	"github.com/pardot/deci/storage"
 	_ "github.com/lib/pq"
+	"github.com/pardot/deci/storage"
 )
-
-var (
-	dbURL = flag.String("db-url", "", "Database URL")
-)
-
-func init() {
-	flag.Parse()
-}
 
 func TestStorage(t *testing.T) {
-	if *dbURL == "" {
-		t.Skip("-db-url not set, skipping")
+	dbURL := os.Getenv("DB_URL")
+	if dbURL == "" {
+		t.Skip("DB_URL not set, skipping")
 	}
 
-	ctx, s := setup(t)
+	ctx, s := setup(t, dbURL)
 	storage.Test(ctx, t, s)
 }
 
-func setup(t *testing.T) (ctx context.Context, s *Storage) {
+func setup(t *testing.T, dbURL string) (ctx context.Context, s *Storage) {
 	ctx = context.Background()
 
-	db, err := sql.Open("postgres", *dbURL)
+	db, err := sql.Open("postgres", dbURL)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Previously reverted in 2f875bc9af260fa6d20481f276bb8dcaee59d22b, I'm proposing bringing it back because certain design patterns around chaining connectors is _much_ easier if the chained connector can intercept (and possibly wrap) the `Authenticator` as it is passed through at initialization time. While in general I support Go structs that are fully initialized when constructed, `Initialize` is, in this case, the more flexible design pattern.

If we ever find a better design pattern for this, I'd be happy to revisit it.