### PR TITLE
Populate ACRValues from Authenticator.LoginRequest

### DIFF
--- a/oidcserver/authenticator.go
+++ b/oidcserver/authenticator.go
@@ -76,8 +76,5 @@ func (a *authenticator) LoginRequest(ctx context.Context, authID string) (LoginR
 		return LoginRequest{}, err
 	}
 
-	return LoginRequest{
-		AuthID: authID,
-		Scopes: parseScopes(authReq.Scopes),
-	}, nil
+	return asLoginRequest(authReq), nil
 }

--- a/oidcserver/handlers.go
+++ b/oidcserver/handlers.go
@@ -196,13 +196,7 @@ func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	lr := LoginRequest{
-		AuthID:    authReqID,
-		Scopes:    parseScopes(authReq.Scopes),
-		ACRValues: authReq.AcrValues,
-	}
-
-	conn.LoginPage(w, r, lr)
+	conn.LoginPage(w, r, asLoginRequest(authReq))
 }
 
 func (s *Server) handleApproval(w http.ResponseWriter, r *http.Request) {
@@ -882,4 +876,12 @@ func offlineSessionID(userID, connID string) string {
 		base64.StdEncoding.EncodeToString([]byte(userID)),
 		base64.StdEncoding.EncodeToString([]byte(connID)),
 	)
+}
+
+func asLoginRequest(authReq *storagepb.AuthRequest) LoginRequest {
+	return LoginRequest{
+		AuthID:    authReq.Id,
+		Scopes:    parseScopes(authReq.Scopes),
+		ACRValues: authReq.AcrValues,
+	}
 }


### PR DESCRIPTION
This ended up being missed since we construct LoginRequest in two places. To make sure this doesn't happen again, I've extracted it to a function.